### PR TITLE
Update instructions for Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # ungoogled-updater
 
-Script for Windows to keep ungoogled-chromium up to date.
----
+## Script for Windows to keep ungoogled-chromium up to date.
 
-Will install/update Chromium in `%PROGRAMDATA%\Ungoogled Chromium\`.
+Will install/update Chromium in `%PROGRAMDATA%\Ungoogled Chromium\` by default.
 
-You can change the install path by changing the `CHROMIUM_PATH` constant in `update.py`.
+You can change the install path by uncommenting the desired `CHROMIUM_PATH` constant in `update.py`.
 
 Binaries are obtained from [Marmaduke's repository](https://github.com/macchrome/winchrome).
 
-**Requires:** Python 3, 7zip, `requests` and `psutil` (`pip3 install requests psutil`).
+**Requires:** Python 3, 7zip, `requests` and `psutil` (and `setuptools` if Python 3.12 or above)
 
-To enable automatic updates (on windows login and daily at `0:00`), run `python update.py --install`. *Updates will only succeed if chromium is not currently running.*
+```bash
+pip3 install requests psutil setuptools
+```
+
+To enable automatic updates (on windows login and daily at `0:00`), run `python update.py --install`. _Updates will only succeed if Chromium is not currently running._

--- a/update.py
+++ b/update.py
@@ -1,6 +1,7 @@
 # exes from https://github.com/macchrome/winchrome/releases
 # requires a valid installation of 7zip.
-# also requires psutil and requests: pip3 install psutil requests
+# also requires psutil, requests and setuptools (replaces distutils in Python >=3.12) 
+# pip3 install psutil requests setuptools
 import os
 import requests
 import winreg


### PR DESCRIPTION
Trying to run the script on Python 3.12.0 prints this error message:

```
Traceback (most recent call last):
  File "D:\Code\git\ungoogled-updater\update.py", line 11, in <module>
    from distutils.dir_util import copy_tree
ModuleNotFoundError: No module named 'distutils'
```

I found the answer on [Stack Overflow](https://stackoverflow.com/questions/77233855/why-did-i-got-an-error-modulenotfounderror-no-module-named-distutils) that `distutils` has been deprecated since Python 3.10 and [removed in 3.12](https://peps.python.org/pep-0632/).

The solution is to install the `setuptools` package, which will let us use the `distutils` API. I don't know if this is a permanent fix that won't require a rewrite, but it seems to get the job done for now.